### PR TITLE
Catch the smtplib.SMTPRecipientsRefused exceptions, acknowledge the e…

### DIFF
--- a/mailmerge/api.py
+++ b/mailmerge/api.py
@@ -97,14 +97,8 @@ def sendmail(text, sender, recipients, config_filename):
 
     # Send message.  Note that we can't use the elegant
     # "smtp.send_message(message)" because that's python3 only
-    try:
-        smtp.sendmail(sender, recipients, text)
-    except smtplib.SMTPRecipientsRefused as err:
-        result = err
-    else:
-        result = 0
+    smtp.sendmail(sender, recipients, text)
     smtp.close()
-    return(result)
 
 
 def create_sample_input_files(template_filename,
@@ -243,13 +237,14 @@ def main(sample=False,
                 print(">>> sent message {} DRY RUN".format(i))
             else:
                 # Send message
-                result = sendmail(text, sender, recipients, config_filename)
-                if (result == 0):
-                    print(">>> sent message {}".format(i))
-                else:
+                try:
+                    sendmail(text, sender, recipients, config_filename)
+                except smtplib.SMTPRecipientsRefused as err:
                     print(">>> failed to send message {}".format(i))
                     timestamp = '{:%Y-%m-%dT%H:%M:%S}'.format(datetime.datetime.now())
-                    print(timestamp, i, result, sep=' ', file=sys.stderr)
+                    print(timestamp, i, err, sep=' ', file=sys.stderr)
+                else:
+                    print(">>> sent message {}".format(i))
 
         # Hints for user
         if not no_limit:

--- a/mailmerge/api.py
+++ b/mailmerge/api.py
@@ -241,7 +241,7 @@ def main(sample=False,
                     sendmail(text, sender, recipients, config_filename)
                 except smtplib.SMTPException as err:
                     print(">>> failed to send message {}".format(i))
-                    timestamp = '{:%Y-%m-%dT%H:%M:%S}'.format(datetime.datetime.now())
+                    timestamp = '{:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now())
                     print(timestamp, i, err, sep=' ', file=sys.stderr)
                 else:
                     print(">>> sent message {}".format(i))

--- a/mailmerge/api.py
+++ b/mailmerge/api.py
@@ -239,7 +239,7 @@ def main(sample=False,
                 # Send message
                 try:
                     sendmail(text, sender, recipients, config_filename)
-                except smtplib.SMTPRecipientsRefused as err:
+                except smtplib.SMTPException as err:
                     print(">>> failed to send message {}".format(i))
                     timestamp = '{:%Y-%m-%dT%H:%M:%S}'.format(datetime.datetime.now())
                     print(timestamp, i, err, sep=' ', file=sys.stderr)


### PR DESCRIPTION
I have to send a lot of messages to a list of address that likely has some bad email addresses on my domain. A single SMTPRecipientsRefused exception will shut down the batch so I added some code to catch the exception, note it and log it to standard error.

I'm only catching smtplib.SMTPRecipientsRefused.  While this is better than nothing, there are plenty more exceptions that could stop the batch in mid-stream. I'm solving the problem I have because I understand it well. 

Test procedures:

- [ ] Create a database with a mix of good and bad usernames on your local domain.
- [ ] run mailmerge to attempt to send them all redirecting stderr to a file.
- [ ] verify that all the bad usernames and only the bad usernames are shown in the error file.
