### PR TITLE
[Bugfix] Remove custom attachment header in sent emails

### DIFF
--- a/mailmerge/api.py
+++ b/mailmerge/api.py
@@ -121,7 +121,7 @@ def addattachments(message, template_path):
         message.attach(part)
         print(">>> attached {}".format(normalized_path))
 
-    del message['attachments']
+    del message['attachment']
     return message, len(attachment_filepaths)
 
 


### PR DESCRIPTION
Fixed code to remove the custom attachment header (that shouldn't be included in the final email).