### PR TITLE
Support distros dropping python2 support

### DIFF
--- a/mailmerge/api.py
+++ b/mailmerge/api.py
@@ -13,8 +13,13 @@ import smtplib
 import configparser
 import getpass
 import datetime
+
 # NOTE: Python 2.x UTF8 support requires csv and email backports
-from backports import csv
+try:
+    from backports import csv
+except ImportError:
+    import csv
+
 import future.backports.email as email  # pylint: disable=useless-import-alias
 import future.backports.email.mime  # pylint: disable=unused-import
 import future.backports.email.mime.application  # pylint: disable=unused-import

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "configparser",
         "jinja2",
         "future",
-        "backports.csv",
+        "backports.csv;python_version<='2.7'",
         "markdown",
     ],
     extras_require={


### PR DESCRIPTION
As python2 moves closer and closer to EOL backports and other packages
from python2 are being dropped.  This makes those conditionally used
so that python3 primary distributions work