### PR TITLE
Adding Feature to optionally get Password from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Your number is 17.
 >>> Limit was 1 messages.  To remove the limit, use the --no-limit option.
 ```
 
-Now, check your email make sure the message went through.  If everything looks OK, then it's time to send all the messages.
+Now, check your email. Make sure the message went through.  If everything looks OK, then it's time to send all the messages. By default you will be asked to type the password into the prompt. Optionally, you can provide the environment variable EMAIL_PASSWORD.
 
 ### Send all emails
 ```console

--- a/mailmerge/sendmail_client.py
+++ b/mailmerge/sendmail_client.py
@@ -3,6 +3,7 @@ SMTP client reads configuration and sends message.
 
 Andrew DeOrio <awdeorio@umich.edu>
 """
+import os
 import smtplib
 import configparser
 import getpass
@@ -27,7 +28,7 @@ class SendmailClient(object):
         self.port = config.getint("smtp_server", "port")
         self.security = config.get("smtp_server", "security")
         self.username = config.get("smtp_server", "username", fallback=None)
-        self.password = None
+        self.password = os.environ.get('EMAIL_PASSWORD')
 
     def sendmail(self, sender, recipients, message):
         """Send email message."""


### PR DESCRIPTION
I had issues on my mac because instead of the prompt the SendmailClient started messing around with my keychain. So I added the feature to provide the password through an environment variable. It was set to None in the init method. os.environ.get("EMAIL_PASSWORD") will fall back to None if no environment variable. So the functionality would remain the same.
I updated the README but was not sure where to place the description of the new feature. I might need some help here.