### PR TITLE
Decode message converting to multipart

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -111,16 +111,21 @@ class TemplateMessage(object):
 
     def _transform_markdown(self):
         """Convert markdown in message text to HTML."""
+        # Do nothing if Content-Type is not text/markdown
         if not self._message['Content-Type'].startswith("text/markdown"):
             return
 
+        # Remove the Content-Type header.  We're about to replace it with HTML.
         del self._message['Content-Type']
-        # Convert the text from markdown and then make the message multipart
+
+        # Make sure the message is multipart.  We need a multipart message so
+        # that we can add an HTML part containing rendered Markdown.
         self._make_message_multipart()
+
+        # Render Markdown.  We assume that the plaintext payload item is
+        # formatted with Markdown.  Render Markdown to HTML and add the HTML as
+        # the last part of the multipart message (as per RFC 2046).
         for payload_item in set(self._message.get_payload()):
-            # Assume the plaintext item is formatted with markdown.
-            # Add corresponding HTML version of the item as the last part of
-            # the multipart message (as per RFC 2046)
             if payload_item['Content-Type'].startswith('text/plain'):
                 original_encoding = str(payload_item.get_charset())
                 original_text = payload_item.get_payload(decode=True) \

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -134,10 +134,13 @@ class TemplateMessage(object):
 
         # Render Markdown to HTML and add the HTML as the last part of the
         # multipart message as per RFC 2046.
+        #
+        # Note: We need to use u"..." to ensure that unicode string
+        # substitution works properly in Python 2.
         html = markdown.markdown(text)
         payload = future.backports.email.mime.text.MIMEText(
-            "<html><body>{}</body></html>".format(html),
-            "html",
+            u"<html><body>{}</body></html>".format(html),
+            u"html",
             _charset=encoding,
         )
         self._message.attach(payload)

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -137,10 +137,12 @@ class TemplateMessage(object):
         #
         # Note: We need to use u"..." to ensure that unicode string
         # substitution works properly in Python 2.
+        #
+        # https://docs.python.org/3/library/email.mime.html#email.mime.text.MIMEText
         html = markdown.markdown(text)
         payload = future.backports.email.mime.text.MIMEText(
             u"<html><body>{}</body></html>".format(html),
-            u"html",
+            _subtype="html",
             _charset=encoding,
         )
         self._message.attach(payload)

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -124,7 +124,7 @@ class TemplateMessage(object):
 
         # Extract unrendered text and encoding.  We assume that the first
         # plaintext payload is formatted with Markdown.
-        for mimetext in set(self._message.get_payload()):
+        for mimetext in self._message.get_payload():
             if mimetext['Content-Type'].startswith('text/plain'):
                 encoding = str(mimetext.get_charset())
                 text = mimetext.get_payload(decode=True).decode(encoding)

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -76,14 +76,19 @@ def test_markdown():
 
     # Ensure that the first part is plaintext and the last part
     # is HTML (as per RFC 2046)
-    plaintext_contenttype = payload[0]['Content-Type']
-    assert plaintext_contenttype.startswith("text/plain")
-    plaintext = payload[0].get_payload()
-    html_contenttype = payload[1]['Content-Type']
-    assert html_contenttype.startswith("text/html")
+    plaintext_part = payload[0]
+    assert plaintext_part['Content-Type'].startswith("text/plain")
+    plaintext_encoding = str(plaintext_part.get_charset())
+    plaintext = plaintext_part.get_payload(decode=True) \
+                              .decode(plaintext_encoding)
+
+    html_part = payload[1]
+    assert html_part['Content-Type'].startswith("text/html")
+    html_encoding = str(html_part.get_charset())
+    htmltext = html_part.get_payload(decode=True) \
+                        .decode(html_encoding)
 
     # Verify rendered Markdown
-    htmltext = payload[1].get_payload()
     rendered = markdown.markdown(plaintext)
     htmltext_correct = "<html><body>{}</body></html>".format(rendered)
     assert htmltext.strip() == htmltext_correct.strip()

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -101,9 +101,12 @@ def test_markdown_encoding():
     https://github.com/awdeorio/mailmerge/issues/59
     """
     template_message = mailmerge.template_message.TemplateMessage(
-        template_path=os.path.join(utils.TESTDATA, "markdown_template_utf8.txt"),
+        template_path=os.path.join(
+            utils.TESTDATA,
+            "markdown_template_utf8.txt",
+        ),
     )
-    sender, recipients, message = template_message.render({
+    _, _, message = template_message.render({
         "email": "myself@mydomain.com",
         "name": "Myself",
     })
@@ -199,7 +202,17 @@ def test_utf8_template():
     # NOTE: to decode a base46-encoded string:
     # print((str(base64.b64decode(payload), "utf-8")))
     payload = message.get_payload().replace("\n", "")
-    assert payload == 'RnJvbSB0aGUgVGFnZWxpZWQgb2YgV29sZnJhbSB2b24gRXNjaGVuYmFjaCAoTWlkZGxlIEhpZ2ggR2VybWFuKToKClPDrm5lIGtsw6J3ZW4gZHVyaCBkaWUgd29sa2VuIHNpbnQgZ2VzbGFnZW4sCmVyIHN0w65nZXQgw7tmIG1pdCBncsO0emVyIGtyYWZ0LAppY2ggc2loIGluIGdyw6J3ZW4gdMOkZ2Vsw65jaCBhbHMgZXIgd2lsIHRhZ2VuLApkZW4gdGFjLCBkZXIgaW0gZ2VzZWxsZXNjaGFmdAplcndlbmRlbiB3aWwsIGRlbSB3ZXJkZW4gbWFuLApkZW4gaWNoIG1pdCBzb3JnZW4gw65uIHZlcmxpZXouCmljaCBicmluZ2UgaW4gaGlubmVuLCBvYiBpY2gga2FuLgpzw65uIHZpbCBtYW5lZ2l1IHR1Z2VudCBtaWNoeiBsZWlzdGVuIGhpZXouCgpodHRwOi8vd3d3LmNvbHVtYmlhLmVkdS9+ZmRjL3V0Zjgv'  # noqa: E501 pylint: disable=line-too-long
+    assert payload == (
+        "RnJvbSB0aGUgVGFnZWxpZWQgb2YgV29sZnJhbSB2b24gRXNjaGVuYmFjaCAo"
+        "TWlkZGxlIEhpZ2ggR2VybWFuKToKClPDrm5lIGtsw6J3ZW4gZHVyaCBkaWUg"
+        "d29sa2VuIHNpbnQgZ2VzbGFnZW4sCmVyIHN0w65nZXQgw7tmIG1pdCBncsO0"
+        "emVyIGtyYWZ0LAppY2ggc2loIGluIGdyw6J3ZW4gdMOkZ2Vsw65jaCBhbHMg"
+        "ZXIgd2lsIHRhZ2VuLApkZW4gdGFjLCBkZXIgaW0gZ2VzZWxsZXNjaGFmdApl"
+        "cndlbmRlbiB3aWwsIGRlbSB3ZXJkZW4gbWFuLApkZW4gaWNoIG1pdCBzb3Jn"
+        "ZW4gw65uIHZlcmxpZXouCmljaCBicmluZ2UgaW4gaGlubmVuLCBvYiBpY2gg"
+        "a2FuLgpzw65uIHZpbCBtYW5lZ2l1IHR1Z2VudCBtaWNoeiBsZWlzdGVuIGhp"
+        "ZXouCgpodHRwOi8vd3d3LmNvbHVtYmlhLmVkdS9+ZmRjL3V0Zjgv"
+    )
 
 
 def test_utf8_database():

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -99,10 +99,7 @@ def test_markdown_encoding():
     https://github.com/awdeorio/mailmerge/issues/59
     """
     template_message = mailmerge.template_message.TemplateMessage(
-        template_path=os.path.join(
-            utils.TESTDATA,
-            "markdown_template_utf8.txt",
-        ),
+        utils.TESTDATA/"markdown_template_utf8.txt"
     )
     _, _, message = template_message.render({
         "email": "myself@mydomain.com",

--- a/tests/testdata/markdown_template_utf8.txt
+++ b/tests/testdata/markdown_template_utf8.txt
@@ -1,0 +1,7 @@
+TO: {{email}}
+SUBJECT: Testing mailmerge
+FROM: test@example.com
+CONTENT-TYPE: text/markdown
+
+Hi, {{name}},
+æøå


### PR DESCRIPTION
## Context
Currently, when converting a non-multipart message to multipart, the code gets the raw payload and attaches that to a new multipart message. (We lose the encoding metadata.) In the example described in #59, the non-multipart message was encoded using UTF-8+Base64, but the multipart message contained the Base64 string without specifying that encoding scheme (which defaulted to ascii).

To fix this, the code should do the following when creating a multipart message (or converting to Markdown):
1. Retain the original encoding information
2. Base64-decode the plaintext before attaching it to the new multipart email (otherwise, the original message is base64-encoded multiple times)

## Validation
1. Create a mailmerge template as described in #59.
2. Run `mailmerge`
3. Output is correctly encoded using Base64, and each part's headers indicate UTF-8 encoding.
```
Content-Type: multipart/alternative; boundary="===============5220678986585785344=="
MIME-Version: 1.0
MIME-Version: 1.0
TO: sesh.sadasivam@gmail.com
SUBJECT: Testing mailmerge
FROM: test@example.com
Content-Transfer-Encoding: base64
Date: Sat, 14 Dec 2019 04:56:26 -0000

--===============5220678986585785344==
Content-Type: text/plain; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: base64

SGksIE15c2VsZiwKw6bDuMOl

--===============5220678986585785344==
Content-Type: text/html; charset="utf-8"
MIME-Version: 1.0
Content-Transfer-Encoding: base64

PGh0bWw+PGJvZHk+PHA+SGksIE15c2VsZiwKw6bDuMOlPC9wPjwvYm9keT48L2h0bWw+

--===============5220678986585785344==--
```

Closes #59.