### PR TITLE
Run linters on Python 3 only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,9 @@
+# Local host configuration.  Run linters, one Python 2 and one Python 3 version
 [tox]
 envlist = lint, py2, py3
 
+# Travis configuration.  Maps Travis Python version to tox env targets.  Because
+# pydocstyle no longer runs on Python 2, we run linters only on Python 3.
 [tox:travis]
 2.7 = py2
 3.4 = py3, lint
@@ -9,6 +12,7 @@ envlist = lint, py2, py3
 3.7 = py3, lint
 3.8 = py3, lint
 
+# Run unit tests
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
@@ -18,6 +22,7 @@ deps =
 commands =
     pytest --verbose --cov mailmerge
 
+# Run linters
 [testenv:lint]
 basepython = python3
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = lint, py2, py3
 
 [tox:travis]
 2.7 = py2
+3.4 = py3, lint
 3.5 = py3, lint
 3.6 = py3, lint
 3.7 = py3, lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,25 @@
 [tox]
-envlist = py2, py3
+envlist = lint, py2, py3
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+deps =
+    pytest
+    pytest-cov
+commands =
+    pytest --verbose --cov mailmerge
+
+[testenv:lint]
+basepython = python3
 deps =
     check-manifest
     pycodestyle
     pydocstyle
     pylint
     pytest
-    pytest-cov
 commands =
     check-manifest
     pycodestyle mailmerge tests setup.py
     pydocstyle mailmerge tests setup.py
     pylint mailmerge setup.py tests
-    pytest --verbose --cov mailmerge

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 envlist = lint, py2, py3
 
+[tox:travis]
+2.7 = py2
+3.5 = py3, lint
+3.6 = py3, lint
+3.7 = py3, lint
+3.8 = py3, lint
+
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
Linters fail on Python 2 because pydocstyle dropped support from Python < 3.4.  Run linters only on Python 3.