### PR TITLE
Add README URL to help message

### DIFF
--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -66,7 +66,7 @@ except ImportError:
 def cli(sample, dry_run, limit, no_limit,
         database_path, template_path, config_path):
     """
-    A simple, command line mail merge tool.
+    Mailmerge is a simple, command line mail merge tool.
 
     For examples and formatting features, see:
     https://github.com/awdeorio/mailmerge

--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -145,11 +145,13 @@ def check_input_files(template_path, database_path, config_path, sample):
         )
         sys.exit(0)
     if not template_path.exists():
-        print("Error: can't find template email " + template_path)
+        print("Error: can't find template email {}".format(template_path))
         print("Create a sample (--sample) or specify a file (--template)")
+        print("")
+        print("See https://github.com/awdeorio/mailmerge for examples.")
         sys.exit(1)
     if not database_path.exists():
-        print("Error: can't find database_path " + database_path)
+        print("Error: can't find database_path {}".format(database_path))
         print("Create a sample (--sample) or specify a file (--database)")
         sys.exit(1)
 

--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -56,7 +56,12 @@ from .utils import MailmergeError
 )
 def cli(sample, dry_run, limit, no_limit,
         database_path, template_path, config_path):
-    """Command line interface."""
+    """
+    Command line interface.
+
+    For guides and other features, see:
+    https://github.com/awdeorio/mailmerge#example.
+    """
     # We need an argument for each command line option.  That also means a lot
     # of local variables.
     # pylint: disable=too-many-arguments, too-many-locals

--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -66,10 +66,10 @@ except ImportError:
 def cli(sample, dry_run, limit, no_limit,
         database_path, template_path, config_path):
     """
-    Command line interface.
+    A simple, command line mail merge tool.
 
-    For guides and other features, see:
-    https://github.com/awdeorio/mailmerge#example.
+    For examples and formatting features, see:
+    https://github.com/awdeorio/mailmerge
     """
     # We need an argument for each command line option.  That also means a lot
     # of local variables.

--- a/tests/test_mailmerge.py
+++ b/tests/test_mailmerge.py
@@ -59,6 +59,12 @@ def test_no_options(tmpdir):
 
     Run mailmerge at the CLI with no options.  Do this in an empty temporary
     directory to ensure that mailmerge doesn't find any default input files.
+
+    pytest tmpdir docs:
+    http://doc.pytest.org/en/latest/tmpdir.html#the-tmpdir-fixture
+
+    sh _ok_code docs
+    https://amoffat.github.io/sh/sections/special_arguments.html#ok-code
     """
     mailmerge = sh.Command("mailmerge")
     with tmpdir.as_cwd():

--- a/tests/test_mailmerge.py
+++ b/tests/test_mailmerge.py
@@ -54,15 +54,14 @@ Your number is 42.
 """
 
 
-def test_no_options():
-    """Verify help message when called with no options."""
-    # FIXME HACK this test assume we're in a folder with no mailmerge_* files
+def test_no_options(tmpdir):
+    """Verify help message when called with no options.
 
-    # Run mailmerge at the CLI with no options.  We expect exit code 1.
-    # https://amoffat.github.io/sh/sections/special_arguments.html#ok-code
+    Run mailmerge at the CLI with no options.  Do this in an empty temporary
+    directory to ensure that mailmerge doesn't find any default input files.
+    """
     mailmerge = sh.Command("mailmerge")
-    output = mailmerge(_ok_code=1)
-
-    # Verify output
+    with tmpdir.as_cwd():
+        output = mailmerge(_ok_code=1)  # expect non-zero exit
     assert "Error: can't find template email mailmerge_template.txt" in output
     assert "https://github.com/awdeorio/mailmerge" in output

--- a/tests/test_mailmerge.py
+++ b/tests/test_mailmerge.py
@@ -9,11 +9,7 @@ from . import utils
 
 
 def test_stdout():
-    """Verify stdout and stderr.
-
-    pytest docs on capturing stdout and stderr
-    https://pytest.readthedocs.io/en/2.7.3/capture.html
-    """
+    """Verify stdout and stderr with dry run on simple input files."""
     mailmerge_cmd = sh.Command("mailmerge")
     output = mailmerge_cmd(
         "--template", utils.TESTDATA/"simple_template.txt",
@@ -56,3 +52,17 @@ Your number is 42.
 >>> sent message 1
 >>> This was a dry run.  To send messages, use the --no-dry-run option.
 """
+
+
+def test_no_options():
+    """Verify help message when called with no options."""
+    # FIXME HACK this test assume we're in a folder with no mailmerge_* files
+
+    # Run mailmerge at the CLI with no options.  We expect exit code 1.
+    # https://amoffat.github.io/sh/sections/special_arguments.html#ok-code
+    mailmerge = sh.Command("mailmerge")
+    output = mailmerge(_ok_code=1)
+
+    # Verify output
+    assert "Error: can't find template email mailmerge_template.txt" in output
+    assert "https://github.com/awdeorio/mailmerge" in output


### PR DESCRIPTION
The mailmerge CLI help message is good, but the README better describe the workflow for using the tool. (The help message also doesn't document features such as attachments and markdown.)

This PR updates the help message with a link to this repository's README. Suggestions for language are welcome 😄