### PR TITLE
Avoid irrelevant hints

### DIFF
--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -127,11 +127,16 @@ def main(sample, dry_run, limit, no_limit, resume,
             )
             message_num += 1
     except MailmergeError as error:
+        hint_text = '\nHint: "--resume {}"'.format(message_num)
         sys.exit(
             "Error on message {message_num}\n"
-            "{error}\n"
-            'Hint: "--resume {message_num}"'
-            .format(message_num=message_num, error=error)
+            "{error}"
+            "{hint}"
+            .format(
+                message_num=message_num,
+                error=error,
+                hint=(hint_text if message_num > 1 else ""),
+            )
         )
 
     # Hints for user

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -799,7 +799,7 @@ def test_resume_too_big(tmpdir):
 
 
 def test_resume_hint_on_config_error(tmpdir):
-    """Verify --resume hint after config file read error."""
+    """Verify *no* --resume hint when error is after first message."""
     # Simple template
     template_path = Path(tmpdir/"mailmerge_template.txt")
     template_path.write_text(textwrap.dedent(u"""\
@@ -830,7 +830,7 @@ def test_resume_hint_on_config_error(tmpdir):
     stdout = error.value.stdout.decode("utf-8")
     stderr = error.value.stderr.decode("utf-8")
     assert stdout == ""
-    assert "--resume 1" in stderr
+    assert "--resume 1" not in stderr
 
 
 def test_resume_hint_on_csv_error(tmpdir):


### PR DESCRIPTION
It's irrelevant to hint the user to `--resume 1`. The first message is the default, and this hint is confusing.

