### PR TITLE
Remove duplicate headers in multipart emails

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -102,20 +102,20 @@ class TemplateMessage(object):
         # Create empty multipart message
         multipart_message = email.mime.multipart.MIMEMultipart('alternative')
 
-        original_encoding = str(self._message.get_charset())
-        # To prevent duplicate keys from being added to the message, remove
-        # these headers from the original message.
-        del self._message['Content-Type']
-        del self._message['MIME-Version']
-
-        # Copy headers, preserving duplicate headers
+        # Copy headers.  Avoid duplicate Content-Type and MIME-Version headers,
+        # which we set explicitely.  MIME-Version was set when we created an
+        # empty mulitpart message.  Content-Type will be set when we copy the
+        # original text later.
         for header_key in set(self._message.keys()):
+            if header_key.lower() in ["content-type", "mime-version"]:
+                continue
             values = self._message.get_all(header_key, failobj=[])
             for value in values:
                 multipart_message[header_key] = value
 
         # Copy text, preserving original encoding
         original_text = self._message.get_payload(decode=True)
+        original_encoding = str(self._message.get_charset())
         multipart_message.attach(email.mime.text.MIMEText(
             original_text,
             _charset=original_encoding,

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -102,6 +102,12 @@ class TemplateMessage(object):
         # Create empty multipart message
         multipart_message = email.mime.multipart.MIMEMultipart('alternative')
 
+        original_encoding = str(self._message.get_charset())
+        # To prevent duplicate keys from being added to the message, remove
+        # these headers from the original message.
+        del self._message['Content-Type']
+        del self._message['MIME-Version']
+
         # Copy headers, preserving duplicate headers
         for header_key in set(self._message.keys()):
             values = self._message.get_all(header_key, failobj=[])
@@ -110,7 +116,6 @@ class TemplateMessage(object):
 
         # Copy text, preserving original encoding
         original_text = self._message.get_payload(decode=True)
-        original_encoding = str(self._message.get_charset())
         multipart_message.attach(email.mime.text.MIMEText(
             original_text,
             _charset=original_encoding,

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -125,6 +125,13 @@ def test_cc_bcc(tmp_path):
     assert "Secret" not in plaintext
 
 
+def is_multipart(message):
+    """Returns whether the message is a valid multipart message."""
+    return message.is_multipart() \
+        and len(message.get_all('content-type')) == 1 \
+        and len(message.get_all('mime-version')) == 1
+
+
 def test_html(tmp_path):
     """Verify HTML template results in a simple rendered message."""
     template_path = tmp_path / "template.txt"
@@ -150,7 +157,7 @@ def test_html(tmp_path):
     assert recipients == ["to@test.com"]
 
     # A simple HTML message is not multipart
-    assert not message.is_multipart()
+    assert not is_multipart(message)
 
     # Verify encoding
     assert message.get_charset() == "us-ascii"
@@ -200,7 +207,7 @@ def test_html_plaintext(tmp_path):
     assert recipients == ["to@test.com"]
 
     # Should be multipart: plaintext and HTML
-    assert message.is_multipart()
+    assert is_multipart(message)
     parts = message.get_payload()
     assert len(parts) == 2
     plaintext_part, html_part = parts
@@ -273,7 +280,7 @@ def test_markdown(tmp_path):
     assert recipients == ["myself@mydomain.com"]
 
     # Verify message is multipart
-    assert message.is_multipart()
+    assert is_multipart(message)
 
     # Make sure there is a plaintext part and an HTML part
     payload = message.get_payload()
@@ -390,7 +397,7 @@ def test_attachment_simple(tmpdir):
     assert recipients == ["to@test.com"]
 
     # Verify message is multipart and contains attachment
-    assert message.is_multipart()
+    assert is_multipart(message)
     attachments = extract_attachments(message)
     assert len(attachments) == 1
 
@@ -579,7 +586,7 @@ def test_attachment_multiple(tmp_path):
     assert recipients == ["myself@mydomain.com"]
 
     # Verify message is multipart
-    assert message.is_multipart()
+    assert is_multipart(message)
 
     # Make sure the attachments are all present and valid
     email_body_present = False

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -626,7 +626,7 @@ def test_attachment_empty(tmp_path):
         template_message.render({})
 
 
-def test_duplicate_headers(tmp_path):
+def test_duplicate_headers_attachment(tmp_path):
     """Verify multipart messages do not contain duplicate headers.
 
     Duplicate headers are rejected by some SMTP servers.
@@ -648,6 +648,31 @@ def test_duplicate_headers(tmp_path):
     template_message = TemplateMessage(template_path)
     _, _, message = template_message.render({
         "message": "Hello world"
+    })
+
+    # Verifty no duplicate headers
+    assert len(message.keys()) == len(set(message.keys()))
+
+
+def test_duplicate_headers_markdown(tmp_path):
+    """Verify multipart messages do not contain duplicate headers.
+
+    Duplicate headers are rejected by some SMTP servers.
+    """
+    template_path = tmp_path / "template.txt"
+    template_path.write_text(textwrap.dedent(u"""\
+        TO: to@test.com
+        SUBJECT: Testing mailmerge
+        FROM: from@test.com
+        CONTENT-TYPE: text/markdown
+
+        ```
+        Message as code block: {{message}}
+        ```
+    """))
+    template_message = TemplateMessage(template_path)
+    _, _, message = template_message.render({
+        "message": "hello world",
     })
 
     # Verifty no duplicate headers


### PR DESCRIPTION
As described in #94, messages that are "made multipart" by `mailmerge` (only with attachments though) are sent with duplicate `Content-Type` and `MIME-Version` headers. 

This PR removes the duplicate headers, and updates the tests to be able to expose the issue in case of a regression.

Thanks @asadbd07 for sharing the basis for this fix!

Closes #94.

## Validation

#### (1) Manually verified the header with an example template with an attachment.

Used the following template:
```
TO: {{email}}
SUBJECT: Testing mailmerge
FROM: My Self <myself@mydomain.com>
ATTACHMENT: tests/testdata/attachment_1.txt

Test
```

Ran `mailmerge --output-format raw --limit 1`.

Before this PR (notice the duplicated headers):
```
>>> message 1
Content-Type: multipart/alternative;
 boundary="===============7959594431702800747=="
MIME-Version: 1.0
SUBJECT: Testing mailmerge
TO: myself@mydomain.com
Content-Type: multipart/alternative;
 boundary="===============7959594431702800747=="
FROM: My Self <myself@mydomain.com>
Content-Transfer-Encoding: 7bit
MIME-Version: 1.0
Date: Sun, 31 May 2020 13:58:58 -0000

--===============7959594431702800747==
Content-Type: text/plain; charset="us-ascii"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit

Test
--===============7959594431702800747==
Content-Type: application/octet-stream; Name="attachment_1.txt"
MIME-Version: 1.0
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename="attachment_1.txt"

VGVzdCBTZW5kIEF0dGFjaG1lbnQgMQo=

--===============7959594431702800747==--
>>> message 1 sent
```

After this PR (notice that the headers are not duplicated):
```
>>> message 1
Content-Type: multipart/alternative;
 boundary="===============6296940810701941081=="
MIME-Version: 1.0
SUBJECT: Testing mailmerge
FROM: My Self <myself@mydomain.com>
TO: myself@mydomain.com
Content-Transfer-Encoding: 7bit
Date: Sun, 31 May 2020 13:56:53 -0000

--===============6296940810701941081==
Content-Type: text/plain; charset="us-ascii"
MIME-Version: 1.0
Content-Transfer-Encoding: 7bit

Test
--===============6296940810701941081==
Content-Type: application/octet-stream; Name="attachment_1.txt"
MIME-Version: 1.0
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename="attachment_1.txt"

VGVzdCBTZW5kIEF0dGFjaG1lbnQgMQo=

--===============6296940810701941081==--
>>> message 1 sent
```

#### (2) Ran the updated tests with and without the fix.
`pytest` fails without the fix. `pytest` passes with the fix.