### PR TITLE
Add default encoding as UTF-8

### DIFF
--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -268,7 +268,7 @@ def read_csv_database(database_path):
         # pylint: disable=too-few-public-methods, missing-class-docstring
         strict = True
 
-    with database_path.open("r") as database_file:
+    with database_path.open(mode="r", encoding="utf-8") as database_file:
         reader = csv.DictReader(database_file, dialect=StrictExcel)
         try:
             for row in reader:


### PR DESCRIPTION
Default encoding on Windows systems is [cp1252](https://en.wikipedia.org/wiki/Windows-1252)
`encoding="utf-8"` fixes the issue with `UnicodeDecodeError` when `mailmerge_database.csv` contains Unicode characters in localized languages.
Thanks to @seshrs and @awdeorio for guiding me through this 😀