### PR TITLE
Retain content-type when adding attachment to non-multipart message

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -115,9 +115,11 @@ class TemplateMessage(object):
 
         # Copy text, preserving original encoding
         original_text = self._message.get_payload(decode=True)
+        original_subtype = self._message.get_content_subtype()
         original_encoding = str(self._message.get_charset())
         multipart_message.attach(email.mime.text.MIMEText(
             original_text,
+            _subtype=original_subtype,
             _charset=original_encoding,
         ))
 

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -611,7 +611,7 @@ def test_attachment_multiple(tmp_path):
 
 
 def test_attachment_empty(tmp_path):
-    """Errr on empty attachment field."""
+    """Err on empty attachment field."""
     template_path = tmp_path / "template.txt"
     template_path.write_text(textwrap.dedent(u"""\
         TO: to@test.com
@@ -624,6 +624,93 @@ def test_attachment_empty(tmp_path):
     template_message = TemplateMessage(template_path)
     with pytest.raises(MailmergeError):
         template_message.render({})
+
+
+def test_attachment_html_body(tmpdir):
+    """
+    Verify that the content-type of the message is correctly retained with an
+    HTML body.
+    """
+    # Simple attachment
+    attachment_path = Path(tmpdir/"attachment.txt")
+    attachment_path.write_text(u"Hello world\n")
+
+    # HTML template
+    template_path = Path(tmpdir/"template.txt")
+    template_path.write_text(textwrap.dedent(u"""\
+        TO: to@test.com
+        FROM: from@test.com
+        ATTACHMENT: attachment.txt
+        CONTENT-TYPE: text/html
+
+        Hello world
+    """))
+
+    # Render in tmpdir
+    with tmpdir.as_cwd():
+        template_message = TemplateMessage(template_path)
+        sender, recipients, message = template_message.render({})
+
+    # Verify sender and recipients
+    assert sender == "from@test.com"
+    assert recipients == ["to@test.com"]
+
+    # Verify message is multipart and contains attachment
+    assert message.is_multipart()
+    attachments = extract_attachments(message)
+    assert len(attachments) == 1
+
+    # Verify that the message content type is HTML
+    payload = message.get_payload()
+    assert len(payload) == 2
+    assert payload[0].get_content_type() == 'text/html'
+
+
+def test_attachment_markdown_body(tmpdir):
+    """
+    Verify that the content-types of the MarkDown message are correct when
+    attachments are included.
+    """
+    # Simple attachment
+    attachment_path = Path(tmpdir/"attachment.txt")
+    attachment_path.write_text(u"Hello world\n")
+
+    # HTML template
+    template_path = Path(tmpdir/"template.txt")
+    template_path.write_text(textwrap.dedent(u"""\
+        TO: to@test.com
+        FROM: from@test.com
+        ATTACHMENT: attachment.txt
+        CONTENT-TYPE: text/markdown
+
+        Hello **world**
+    """))
+
+    # Render in tmpdir
+    with tmpdir.as_cwd():
+        template_message = TemplateMessage(template_path)
+        sender, recipients, message = template_message.render({})
+
+    # Verify sender and recipients
+    assert sender == "from@test.com"
+    assert recipients == ["to@test.com"]
+
+    # Verify message is multipart and contains attachment
+    assert message.is_multipart()
+    attachments = extract_attachments(message)
+    assert len(attachments) == 1
+
+    # Markdown: Make sure there is a plaintext part and an HTML part
+    payload = message.get_payload()
+    assert len(payload) == 3
+
+    # Ensure that the first part is plaintext and the second part
+    # is HTML (as per RFC 2046)
+    plaintext_part = payload[0]
+    assert plaintext_part['Content-Type'].startswith("text/plain")
+
+    html_part = payload[1]
+    assert html_part['Content-Type'].startswith("text/html")
 
 
 def test_duplicate_headers_attachment(tmp_path):

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -626,7 +626,7 @@ def test_attachment_empty(tmp_path):
         template_message.render({})
 
 
-def test_contenttype_attachment_html_body(tmpdir):
+def test_attachment_html_body(tmpdir):
     """
     Verify that the content-type of the message is correctly retained with an
     HTML body.
@@ -649,7 +649,16 @@ def test_contenttype_attachment_html_body(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        _, _, message = template_message.render({})
+        sender, recipients, message = template_message.render({})
+
+    # Verify sender and recipients
+    assert sender == "from@test.com"
+    assert recipients == ["to@test.com"]
+
+    # Verify message is multipart and contains attachment
+    assert message.is_multipart()
+    attachments = extract_attachments(message)
+    assert len(attachments) == 1
 
     # Verify that the message content type is HTML
     payload = message.get_payload()
@@ -657,7 +666,7 @@ def test_contenttype_attachment_html_body(tmpdir):
     assert payload[0].get_content_type() == 'text/html'
 
 
-def test_contenttype_attachment_markdown_body(tmpdir):
+def test_attachment_markdown_body(tmpdir):
     """
     Verify that the content-types of the MarkDown message are correct when
     attachments are included.
@@ -680,7 +689,16 @@ def test_contenttype_attachment_markdown_body(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        _, _, message = template_message.render({})
+        sender, recipients, message = template_message.render({})
+
+    # Verify sender and recipients
+    assert sender == "from@test.com"
+    assert recipients == ["to@test.com"]
+
+    # Verify message is multipart and contains attachment
+    assert message.is_multipart()
+    attachments = extract_attachments(message)
+    assert len(attachments) == 1
 
     # Markdown: Make sure there is a plaintext part and an HTML part
     payload = message.get_payload()

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -626,7 +626,7 @@ def test_attachment_empty(tmp_path):
         template_message.render({})
 
 
-def test_attachment_html_body(tmpdir):
+def test_contenttype_attachment_html_body(tmpdir):
     """
     Verify that the content-type of the message is correctly retained with an
     HTML body.
@@ -649,16 +649,7 @@ def test_attachment_html_body(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        sender, recipients, message = template_message.render({})
-
-    # Verify sender and recipients
-    assert sender == "from@test.com"
-    assert recipients == ["to@test.com"]
-
-    # Verify message is multipart and contains attachment
-    assert message.is_multipart()
-    attachments = extract_attachments(message)
-    assert len(attachments) == 1
+        _, _, message = template_message.render({})
 
     # Verify that the message content type is HTML
     payload = message.get_payload()
@@ -666,7 +657,7 @@ def test_attachment_html_body(tmpdir):
     assert payload[0].get_content_type() == 'text/html'
 
 
-def test_attachment_markdown_body(tmpdir):
+def test_contenttype_attachment_markdown_body(tmpdir):
     """
     Verify that the content-types of the MarkDown message are correct when
     attachments are included.
@@ -689,16 +680,7 @@ def test_attachment_markdown_body(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        sender, recipients, message = template_message.render({})
-
-    # Verify sender and recipients
-    assert sender == "from@test.com"
-    assert recipients == ["to@test.com"]
-
-    # Verify message is multipart and contains attachment
-    assert message.is_multipart()
-    attachments = extract_attachments(message)
-    assert len(attachments) == 1
+        _, _, message = template_message.render({})
 
     # Markdown: Make sure there is a plaintext part and an HTML part
     payload = message.get_payload()


### PR DESCRIPTION
## Context

As described in [my comment](https://github.com/awdeorio/mailmerge/issues/100#issuecomment-669970003) in #100, we should preserve the content-subtype of the original message just like we preserve the content's character-encoding. I also added a couple of tests to verify that content-types are correctly processed when using attachments with HTML emails and with MarkDown emails.

Fixes #100.

## Validation

1) `pytest` fails without the change to `template_message.py`.
2) Use [template](https://github.com/awdeorio/mailmerge/issues/100#issue-673863918) provided by @captn3m0 in #100. Before the fix, the output of `mailmerge --dry-run` shows a content-type of `text/plain`. After the fix, the content-type is `text/html` as expected.