### PR TITLE
Add --dump-to option to save the messages to the filesystem

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -37,12 +37,13 @@ class TemplateMessage(object):
     # https://python-future.org/compatible_idioms.html#custom-class-behaviour
     # pylint: disable=bad-option-value,useless-object-inheritance
 
-    def __init__(self, template_path):
+    def __init__(self, template_path, dump_to=None):
         """Initialize variables and Jinja2 template."""
         self.template_path = Path(template_path)
         self._message = None
         self._sender = None
         self._recipients = None
+        self._dump_to_path = None
 
         # Configure Jinja2 template engine with the template dirname as root.
         #
@@ -55,6 +56,8 @@ class TemplateMessage(object):
         self.template = template_env.get_template(
             template_path.parts[-1],  # basename
         )
+        self.dump_to_template = None if dump_to is None else \
+            template_env.from_string(dump_to)
 
     def render(self, context):
         """Return rendered message object."""
@@ -73,7 +76,10 @@ class TemplateMessage(object):
         assert self._sender
         assert self._recipients
         assert self._message
-        return self._sender, self._recipients, self._message
+        if self.dump_to_template is not None:
+            self._dump_to_path = self.dump_to_template.render(context)
+        return self._sender, self._recipients, self._message, \
+            self._dump_to_path
 
     def _transform_encoding(self, raw_message):
         """Detect and set character encoding."""

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -33,7 +33,7 @@ def test_simple(tmp_path):
         Hello {{name}}!
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "name": "world",
     })
     assert sender == "from@test.com"
@@ -53,7 +53,7 @@ def test_no_substitutions(tmp_path):
         Hello world!
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({})
+    sender, recipients, message, _ = template_message.render({})
     assert sender == "from@test.com"
     assert recipients == ["to@test.com"]
     plaintext = message.get_payload()
@@ -72,7 +72,7 @@ def test_multiple_substitutions(tmp_path):
         Your number is {{number}}.
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "email": "myself@mydomain.com",
         "name": "Myself",
         "number": 17,
@@ -106,7 +106,7 @@ def test_cc_bcc(tmp_path):
         Hello world
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "email": "myself@mydomain.com",
     })
 
@@ -141,7 +141,7 @@ def test_html(tmp_path):
         </html>
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "message": "Hello world"
     })
 
@@ -191,7 +191,7 @@ def test_html_plaintext(tmp_path):
         </html>
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "message": "Hello world"
     })
 
@@ -224,6 +224,7 @@ def test_html_plaintext(tmp_path):
 
 def test_markdown(tmp_path):
     """Markdown messages should be converted to HTML."""
+    # pylint: disable=R0914
     template_path = tmp_path / "template.txt"
     template_path.write_text(textwrap.dedent(u"""\
         TO: {{email}}
@@ -262,7 +263,7 @@ def test_markdown(tmp_path):
             http://pluspng.com/img-png/python-logo-png-open-2000.png)
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "email": "myself@mydomain.com",
         "name": "Myself",
         "number": 17,
@@ -316,7 +317,7 @@ def test_markdown_encoding(tmp_path):
         æøå
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({
+    _, _, message, _ = template_message.render({
         "email": "myself@mydomain.com",
         "name": "Myself",
     })
@@ -383,7 +384,7 @@ def test_attachment_simple(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        sender, recipients, message = template_message.render({})
+        sender, recipients, message, _ = template_message.render({})
 
     # Verify sender and recipients
     assert sender == "from@test.com"
@@ -418,7 +419,7 @@ def test_attachment_relative(tmpdir):
 
     # Render
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({})
+    _, _, message, _ = template_message.render({})
 
     # Verify directory used to render is different from template directory
     assert os.getcwd() != tmpdir
@@ -450,7 +451,7 @@ def test_attachment_absolute(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        _, _, message = template_message.render({})
+        _, _, message, _ = template_message.render({})
 
     # Verify attachment
     attachments = extract_attachments(message)
@@ -479,7 +480,7 @@ def test_attachment_template(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        _, _, message = template_message.render({
+        _, _, message, _ = template_message.render({
             "filename": str(attachment_path),
         })
 
@@ -568,7 +569,7 @@ def test_attachment_multiple(tmp_path):
         Your number is {{number}}.
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "email": "myself@mydomain.com",
         "name": "Myself",
         "number": 17,
@@ -649,7 +650,7 @@ def test_contenttype_attachment_html_body(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        _, _, message = template_message.render({})
+        _, _, message, _ = template_message.render({})
 
     # Verify that the message content type is HTML
     payload = message.get_payload()
@@ -680,7 +681,7 @@ def test_contenttype_attachment_markdown_body(tmpdir):
     # Render in tmpdir
     with tmpdir.as_cwd():
         template_message = TemplateMessage(template_path)
-        _, _, message = template_message.render({})
+        _, _, message, _ = template_message.render({})
 
     # Markdown: Make sure there is a plaintext part and an HTML part
     payload = message.get_payload()
@@ -715,7 +716,7 @@ def test_duplicate_headers_attachment(tmp_path):
         {{message}}
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({
+    _, _, message, _ = template_message.render({
         "message": "Hello world"
     })
 
@@ -740,7 +741,7 @@ def test_duplicate_headers_markdown(tmp_path):
         ```
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({
+    _, _, message, _ = template_message.render({
         "message": "hello world",
     })
 

--- a/tests/test_template_message_encodings.py
+++ b/tests/test_template_message_encodings.py
@@ -32,7 +32,7 @@ def test_utf8_template(tmp_path):
         http://www.columbia.edu/~fdc/utf8/
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "email": "myself@mydomain.com",
     })
 
@@ -75,7 +75,7 @@ def test_utf8_database(tmp_path):
 
     # Render template with context containing unicode characters
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({
+    sender, recipients, message, _ = template_message.render({
         "name": u"Laȝamon",
     })
 
@@ -104,7 +104,7 @@ def test_utf8_to(tmp_path):
         {{message}}
     """))
     template_message = TemplateMessage(template_path)
-    _, recipients, message = template_message.render({
+    _, recipients, message, _ = template_message.render({
         "message": "hello",
     })
 
@@ -123,7 +123,7 @@ def test_utf8_from(tmp_path):
         {{message}}
     """))
     template_message = TemplateMessage(template_path)
-    sender, _, message = template_message.render({
+    sender, _, message, _ = template_message.render({
         "message": "hello",
     })
 
@@ -143,7 +143,7 @@ def test_utf8_subject(tmp_path):
         {{message}}
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({
+    _, _, message, _ = template_message.render({
         "message": "hello",
     })
 
@@ -162,7 +162,7 @@ def test_emoji(tmp_path):
         Hi 😀
     """))  # grinning face emoji
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({})
+    _, _, message, _ = template_message.render({})
 
     # Verify encoding
     assert message.get_charset() == "utf-8"
@@ -187,7 +187,7 @@ def test_emoji_markdown(tmp_path):
         ```
             """))  # grinning face emoji
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({})
+    _, _, message, _ = template_message.render({})
 
     # Message should contain an unrendered Markdown plaintext part and a
     # rendered Markdown HTML part
@@ -226,7 +226,7 @@ def test_emoji_database(tmp_path):
         Hi {{emoji}}
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({
+    _, _, message, _ = template_message.render({
         "emoji": u"😀"  # grinning face
     })
 
@@ -249,7 +249,7 @@ def test_encoding_us_ascii(tmp_path):
         Hello world
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({})
+    _, _, message, _ = template_message.render({})
     assert message.get_charset() == "us-ascii"
     assert message.get_content_charset() == "us-ascii"
     assert message.get_payload() == "Hello world"
@@ -265,7 +265,7 @@ def test_encoding_utf8(tmp_path):
         Hello Laȝamon
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({})
+    _, _, message, _ = template_message.render({})
     assert message.get_charset() == "utf-8"
     assert message.get_content_charset() == "utf-8"
     plaintext = message.get_payload(decode=True).decode("utf-8")
@@ -285,7 +285,7 @@ def test_encoding_is8859_1(tmp_path):
         Hello L'Haÿ-les-Roses
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({})
+    _, _, message, _ = template_message.render({})
     assert message.get_charset() == "utf-8"
     assert message.get_content_charset() == "utf-8"
     plaintext = message.get_payload(decode=True).decode("utf-8")
@@ -306,7 +306,7 @@ def test_encoding_mismatch(tmp_path):
         Hello Laȝamon
     """))
     template_message = TemplateMessage(template_path)
-    _, _, message = template_message.render({})
+    _, _, message, _ = template_message.render({})
     assert message.get_charset() == "utf-8"
     assert message.get_content_charset() == "utf-8"
     plaintext = message.get_payload(decode=True).decode("utf-8")
@@ -340,7 +340,7 @@ def test_encoding_multipart(tmp_path):
         </html>
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({})
+    sender, recipients, message, _ = template_message.render({})
 
     # Verify sender and recipients
     assert sender == "from@test.com"
@@ -399,7 +399,7 @@ def test_encoding_multipart_mismatch(tmp_path):
         </html>
     """))
     template_message = TemplateMessage(template_path)
-    sender, recipients, message = template_message.render({})
+    sender, recipients, message, _ = template_message.render({})
 
     # Verify sender and recipients
     assert sender == "from@test.com"


### PR DESCRIPTION
This adds a `--dump-to` option, which can be:

* either a path to an existing directory (in which N.eml files will be created)
* or a jinja template specifying the file names to create (e.g. `./{{_mailmerge_message_num}}.eml`)

The feature was requested in https://github.com/awdeorio/mailmerge/issues/103

There are no tests and I didn't check anything more complex than running pytest on Python 3.8, but once the approach is agreed on I can go through the [instructions](https://github.com/awdeorio/mailmerge/blob/develop/CONTRIBUTING.md#testing-and-code-quality).
(Python 2 is EOL, do you still want to support it?)