### PR TITLE
Fix multipart email structure

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+# Python 2 source containing unicode https://www.python.org/dev/peps/pep-0263/
 """
 Represent a templated email message.
 

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -183,8 +183,8 @@ class TemplateMessage(object):
         # substitution works properly in Python 2.
         #
         # https://docs.python.org/3/library/email.mime.html#email.mime.text.MIMEText
-        html_payload = markdown.markdown(text, extensions=['nl2br'])
-        payload = future.backports.email.mime.text.MIMEText(
+        html = markdown.markdown(text, extensions=['nl2br'])
+        html_payload = future.backports.email.mime.text.MIMEText(
             u"<html><body>{}</body></html>".format(html),
             _subtype="html",
             _charset=encoding,

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -274,20 +274,26 @@ def test_markdown(tmp_path):
 
     # Verify message is multipart
     assert message.is_multipart()
+    assert message.get_content_subtype() == "mixed"
 
-    # Make sure there is a plaintext part and an HTML part
-    payload = message.get_payload()
-    assert len(payload) == 2
+    # Make sure there is a single multipart/alternative payload
+    assert len(message.get_payload()) == 1
+    assert message.get_payload()[0].is_multipart()
+    assert message.get_payload()[0].get_content_subtype() == "alternative"
+
+    # And there should be a plaintext part and an HTML part
+    message_payload = message.get_payload()[0].get_payload()
+    assert len(message_payload) == 2
 
     # Ensure that the first part is plaintext and the last part
     # is HTML (as per RFC 2046)
-    plaintext_part = payload[0]
+    plaintext_part = message_payload[0]
     assert plaintext_part['Content-Type'].startswith("text/plain")
     plaintext_encoding = str(plaintext_part.get_charset())
     plaintext = plaintext_part.get_payload(decode=True) \
                               .decode(plaintext_encoding)
 
-    html_part = payload[1]
+    html_part = message_payload[1]
     assert html_part['Content-Type'].startswith("text/html")
     html_encoding = str(html_part.get_charset())
     htmltext = html_part.get_payload(decode=True) \
@@ -323,7 +329,7 @@ def test_markdown_encoding(tmp_path):
 
     # Message should contain an unrendered Markdown plaintext part and a
     # rendered Markdown HTML part
-    plaintext_part, html_part = message.get_payload()
+    plaintext_part, html_part = message.get_payload()[0].get_payload()
 
     # Verify encodings
     assert str(plaintext_part.get_charset()) == "utf-8"
@@ -682,16 +688,19 @@ def test_contenttype_attachment_markdown_body(tmpdir):
         template_message = TemplateMessage(template_path)
         _, _, message = template_message.render({})
 
-    # Markdown: Make sure there is a plaintext part and an HTML part
     payload = message.get_payload()
-    assert len(payload) == 3
+    assert len(payload) == 2
+
+    # Markdown: Make sure there is a plaintext part and an HTML part
+    message_payload = payload[0].get_payload()
+    assert len(message_payload) == 2
 
     # Ensure that the first part is plaintext and the second part
     # is HTML (as per RFC 2046)
-    plaintext_part = payload[0]
+    plaintext_part = message_payload[0]
     assert plaintext_part['Content-Type'].startswith("text/plain")
 
-    html_part = payload[1]
+    html_part = message_payload[1]
     assert html_part['Content-Type'].startswith("text/html")
 
 

--- a/tests/test_template_message_encodings.py
+++ b/tests/test_template_message_encodings.py
@@ -191,7 +191,8 @@ def test_emoji_markdown(tmp_path):
 
     # Message should contain an unrendered Markdown plaintext part and a
     # rendered Markdown HTML part
-    plaintext_part, html_part = message.get_payload()
+    message_payload = message.get_payload()[0]
+    plaintext_part, html_part = message_payload.get_payload()
 
     # Verify encodings
     assert str(plaintext_part.get_charset()) == "utf-8"


### PR DESCRIPTION
## Context

As discussed in https://stackoverflow.com/a/3984262/5868796, multipart emails should have mime-type `multipart/mixed`. The markdown transformation must embed the text/html message payloads in a `multipart/alternative` payload. Hence, the final payload-structure of an email with attachments transformed by markdown would be:

- `multipart/mixed`
  - `multipart/alternative`
    - `text/plain`
    - `text/html`
  - `attachment 1`
  - `attachment 2`
  - ...

This PR fixes the email structure of multipart messages with attachments and/or contain transformed Markdown. This commit also updates the unit tests to check for the above structure.

Closes #113.

## Validation

I sent an email with Markdown and an attachment, and viewed the email on Gmail and on the native MacOS Mail client. The email showed correctly in both cases:

**Gmail:**
<img src="https://user-images.githubusercontent.com/12139762/110222482-7ce23a00-7ea0-11eb-92e2-707cabcfa841.png" width="300">


**MacOS Mail client:**
<img src="https://user-images.githubusercontent.com/12139762/110222470-62a85c00-7ea0-11eb-872c-431bfdbd5d11.png" width="300">
