### PR TITLE
Use New-Line-to-Break markdown extension

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -156,7 +156,7 @@ class TemplateMessage(object):
         # substitution works properly in Python 2.
         #
         # https://docs.python.org/3/library/email.mime.html#email.mime.text.MIMEText
-        html = markdown.markdown(text)
+        html = markdown.markdown(text, extensions=['nl2br'])
         payload = future.backports.email.mime.text.MIMEText(
             u"<html><body>{}</body></html>".format(html),
             _subtype="html",

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -335,7 +335,8 @@ def test_markdown_encoding(tmp_path):
     plaintext = plaintext_part.get_payload(decode=True).decode("utf-8")
     htmltext = html_part.get_payload(decode=True).decode("utf-8")
     assert plaintext == u"Hi, Myself,\næøå"
-    assert htmltext == u"<html><body><p>Hi, Myself,<br />\næøå</p></body></html>"
+    assert htmltext == \
+        u"<html><body><p>Hi, Myself,<br />\næøå</p></body></html>"
 
 
 Attachment = collections.namedtuple(

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -294,7 +294,7 @@ def test_markdown(tmp_path):
                         .decode(html_encoding)
 
     # Verify rendered Markdown
-    rendered = markdown.markdown(plaintext)
+    rendered = markdown.markdown(plaintext, extensions=['nl2br'])
     htmltext_correct = "<html><body>{}</body></html>".format(rendered)
     assert htmltext.strip() == htmltext_correct.strip()
 
@@ -335,7 +335,7 @@ def test_markdown_encoding(tmp_path):
     plaintext = plaintext_part.get_payload(decode=True).decode("utf-8")
     htmltext = html_part.get_payload(decode=True).decode("utf-8")
     assert plaintext == u"Hi, Myself,\næøå"
-    assert htmltext == u"<html><body><p>Hi, Myself,\næøå</p></body></html>"
+    assert htmltext == u"<html><body><p>Hi, Myself,<br />\næøå</p></body></html>"
 
 
 Attachment = collections.namedtuple(


### PR DESCRIPTION
## Context

While testing #115, I noticed that newline characters (`'\n'`) in a markdown template were not rendered on both Gmail and on the native MacOS mail client.

This commit includes the Python Markdown extension [`nl2br`](https://python-markdown.github.io/extensions/nl2br/) to include HTML `<br />` tags whenever single newline characters are present in the Markdown.

## Validation

I used the following `mailmerge_template.txt`:

```
TO: {{email}}
SUBJECT: Testing mailmerge
FROM: Sesh <sesh.sadasivam@gmail.com>
Content-type: text/markdown

Hi {{ name }},

This is a _mailmerge_ test.

Best,
Sesh
```

In the screenshots below, notice the line-break in `Best, Sesh`.

<table>
<tr>
  <th></th>
  <th>Before</th>
  <th>After</th>
</tr>
<tr>
  <th>Gmail</th>
  <td><img src="https://user-images.githubusercontent.com/12139762/110223832-a69d6000-7ea4-11eb-9849-fb77bcc435ef.png"></td>
  <td><img src="https://user-images.githubusercontent.com/12139762/110223174-6dfd8680-7ea4-11eb-8657-6acc4cea67a7.png"></td>
</tr>
<tr>
  <th>MacOS Mail app</th>
  <td><img src="https://user-images.githubusercontent.com/12139762/110223824-95545380-7ea4-11eb-9ced-fff0390990ea.png"></td>
  <td><img src="https://user-images.githubusercontent.com/12139762/110222947-427a9c00-7ea4-11eb-85a1-040dbac03610.png"></td>
</tr>
</table>