### PR TITLE
User and EditorConfig to help with style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Indentation override for all JS under lib directory
+[lib/**.js]
+indent_style = space
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,6 @@ graft tests
 
 # Avoid dev and and binary files
 exclude tox.ini
+exclude .editorconfig
 global-exclude *.pyc
 global-exclude __pycache__


### PR DESCRIPTION
Since PyLint is strict when it comes to style, It heps for developers to have a `.editorconfig` file and an editor that supports it.