### PR TITLE
Fix tox config for pydocstyle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,6 @@ jobs:
       # Upload coverage report
       # https://github.com/codecov/codecov-action
       - name: Upload coverage report
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,7 +31,7 @@ def test_enumerate_range_stop_value():
 def test_enumerate_range_stop_zero():
     """Verify stop=0."""
     output = list(enumerate_range(["a", "b", "c"], stop=0))
-    assert output == []
+    assert not output
 
 
 def test_enumerate_range_stop_too_big():
@@ -61,13 +61,13 @@ def test_enumerate_range_start_last_one():
 def test_enumerate_range_start_length():
     """Verify start=length."""
     output = list(enumerate_range(["a", "b", "c"], start=3))
-    assert output == []
+    assert not output
 
 
 def test_enumerate_range_start_too_big():
     """Verify start past the end."""
     output = list(enumerate_range(["a", "b", "c"], start=10))
-    assert output == []
+    assert not output
 
 
 def test_enumerate_range_start_stop():

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -660,10 +660,7 @@ def test_attachment_empty(tmp_path):
 
 
 def test_contenttype_attachment_html_body(tmpdir):
-    """
-    Verify that the content-type of the message is correctly retained with an
-    HTML body.
-    """
+    """Content-type is preserved in HTML body."""
     # Simple attachment
     attachment_path = Path(tmpdir/"attachment.txt")
     attachment_path.write_text("Hello world\n", encoding="utf8")
@@ -691,10 +688,7 @@ def test_contenttype_attachment_html_body(tmpdir):
 
 
 def test_contenttype_attachment_markdown_body(tmpdir):
-    """
-    Verify that the content-types of the MarkDown message are correct when
-    attachments are included.
-    """
+    """Content-type for MarkDown messages with attachments."""
     # Simple attachment
     attachment_path = Path(tmpdir/"attachment.txt")
     attachment_path.write_text("Hello world\n", encoding="utf8")
@@ -785,7 +779,7 @@ def test_duplicate_headers_markdown(tmp_path):
 
 
 def test_attachment_image_in_markdown(tmp_path):
-    """Images sent as attachments should get linked correctly in images"""
+    """Images sent as attachments should get linked correctly in images."""
     shutil.copy(str(utils.TESTDATA/"attachment_3.jpg"), str(tmp_path))
 
     # Create template .txt file
@@ -842,7 +836,7 @@ def test_attachment_image_in_markdown(tmp_path):
 
 
 def test_content_id_header_for_attachments(tmpdir):
-    """All attachments should get a content-id header"""
+    """All attachments should get a content-id header."""
     attachment_path = Path(tmpdir/"attachment.txt")
     attachment_path.write_text("Hello world\n", encoding="utf8")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # Local host configuration with one Python 3 version
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
 
 # GitHub Actions configuration with multiple Python versions
 # https://github.com/ymyzk/tox-gh-actions#tox-gh-actions-configuration
@@ -10,15 +10,18 @@ python =
   3.7: py37
   3.8: py38
   3.9: py39
+  3.10: py310
 
 # Run unit tests
+# HACK: Pydocstyle fails to find tests.  Invoke a shell to use a glob.
 [testenv]
 setenv =
   PYTHONPATH = {toxinidir}
+allowlist_externals = sh
 extras = test
 commands =
   pycodestyle mailmerge tests setup.py
-  pydocstyle mailmerge tests setup.py
+  sh -c "pydocstyle mailmerge tests/* setup.py"
   pylint mailmerge tests setup.py
   check-manifest
   pytest -vvs --cov mailmerge


### PR DESCRIPTION
pydocstyle was failing to find files, used a shell glob to fix.

This PR also fixes a codecov GitHub Actions problem by bumping the version.