### PR TITLE
Change mimetype to support inline images in thunderbird

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -95,7 +95,7 @@ class TemplateMessage:
             return
 
         # Create empty multipart message
-        multipart_message = email.mime.multipart.MIMEMultipart('mixed')
+        multipart_message = email.mime.multipart.MIMEMultipart('related')
 
         # Copy headers.  Avoid duplicate Content-Type and MIME-Version headers,
         # which we set explicitely.  MIME-Version was set when we created an

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -87,7 +87,7 @@ class TemplateMessage:
         Convert self._message into a multipart message.
 
         Specifically, if the message's content-type is not multipart, this
-        method will create a new `multipart/mixed` message, copy message
+        method will create a new `multipart/related` message, copy message
         headers and re-attach the original payload.
         """
         # Do nothing if message already multipart
@@ -128,13 +128,13 @@ class TemplateMessage:
         Specifically, if the message's content-type is `text/markdown`, we
         transform `self._message` to have the following structure:
 
-        multipart/mixed
+        multipart/related
          └── multipart/alternative
              ├── text/plain (original markdown plaintext)
              └── text/html (converted markdown)
 
         Attachments should be added as subsequent payload items of the
-        top-level `multipart/mixed` message.
+        top-level `multipart/related` message.
         """
         # Do nothing if Content-Type is not text/markdown
         if not self._message['Content-Type'].startswith("text/markdown"):
@@ -186,11 +186,11 @@ class TemplateMessage:
         """
         Parse attachment headers and generate content-id headers for each.
 
-        Attachments are added to the payload of a `multipart/mixed` message.
+        Attachments are added to the payload of a `multipart/related` message.
         For instance, a plaintext message with attachments would have the
         following structure:
 
-        multipart/mixed
+        multipart/related
          ├── text/plain
          ├── attachment1
          └── attachment2
@@ -199,7 +199,7 @@ class TemplateMessage:
         then the message would have the following structure after transforming
         markdown and attachments:
 
-        multipart/mixed
+        multipart/related
          ├── multipart/alternative
          │   ├── text/plain
          │   └── text/html

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -300,7 +300,7 @@ def test_markdown(tmp_path):
 
     # Verify message is multipart
     assert message.is_multipart()
-    assert message.get_content_subtype() == "mixed"
+    assert message.get_content_subtype() == "related"
 
     # Make sure there is a single multipart/alternative payload
     assert len(message.get_payload()) == 1


### PR DESCRIPTION
Change the content type from `multipart/mixed` to `multipart/related` so
that thunderbird will correctly recognize inline images.

Closes #142