### PR TITLE
Drop Python 3.6 from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       # Define OS and Python versions to use. 3.x is the latest minor version.
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.x"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.x"]
         os: [ubuntu-latest]
 
     # Sequence of tasks for this job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       # Define OS and Python versions to use. 3.x is the latest minor version.
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.x"]
+        python-version: ["3.7", "3.8", "3.9", "3.x"]
         os: [ubuntu-latest]
 
     # Sequence of tasks for this job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       # Define OS and Python versions to use. 3.x is the latest minor version.
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.x"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.x"]
         os: [ubuntu-latest]
 
     # Sequence of tasks for this job

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -58,7 +58,7 @@ class TemplateMessage:
         self._transform_markdown()
         self._transform_attachments()
         self._transform_attachment_references()
-        self._message.__setitem__('Date', email.utils.formatdate())
+        self._message.Date = email.utils.formatdate()
         assert self._sender
         assert self._recipients
         assert self._message
@@ -79,7 +79,7 @@ class TemplateMessage:
             email.utils.getaddresses(self._message.get_all("CC", [])) + \
             email.utils.getaddresses(self._message.get_all("BCC", []))
         self._recipients = [x[1] for x in addrs]
-        self._message.__delitem__("bcc")
+        del self._message.bcc
         self._sender = self._message["from"]
 
     def _make_message_multipart(self):

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -58,7 +58,7 @@ class TemplateMessage:
         self._transform_markdown()
         self._transform_attachments()
         self._transform_attachment_references()
-        self._message.Date = email.utils.formatdate()
+        setattr(self._message, "Date", email.utils.formatdate())
         assert self._sender
         assert self._recipients
         assert self._message
@@ -79,7 +79,8 @@ class TemplateMessage:
             email.utils.getaddresses(self._message.get_all("CC", [])) + \
             email.utils.getaddresses(self._message.get_all("BCC", []))
         self._recipients = [x[1] for x in addrs]
-        del self._message.bcc
+        if hasattr(self._message, "bcc"):
+            delattr(self._message, "bcc")
         self._sender = self._message["from"]
 
     def _make_message_multipart(self):

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -74,11 +74,14 @@ class TemplateMessage:
 
     def _transform_recipients(self):
         """Extract sender and recipients from FROM, TO, CC and BCC fields."""
+        # The docs recommend using __delitem__()
+        # https://docs.python.org/3/library/email.message.html#email.message.EmailMessage.__delitem__
+        # pylint: disable=unnecessary-dunder-call
         addrs = email.utils.getaddresses(self._message.get_all("TO", [])) + \
             email.utils.getaddresses(self._message.get_all("CC", [])) + \
             email.utils.getaddresses(self._message.get_all("BCC", []))
         self._recipients = [x[1] for x in addrs]
-        self._message.__delitem__("bcc")  # pylint: disable=unnecessary-dunder-call
+        self._message.__delitem__("bcc")
         self._sender = self._message["from"]
 
     def _make_message_multipart(self):

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -58,7 +58,7 @@ class TemplateMessage:
         self._transform_markdown()
         self._transform_attachments()
         self._transform_attachment_references()
-        setattr(self._message, "Date", email.utils.formatdate())
+        self._message.add_header('Date', email.utils.formatdate())
         assert self._sender
         assert self._recipients
         assert self._message
@@ -74,13 +74,11 @@ class TemplateMessage:
 
     def _transform_recipients(self):
         """Extract sender and recipients from FROM, TO, CC and BCC fields."""
-        # Extract recipients
         addrs = email.utils.getaddresses(self._message.get_all("TO", [])) + \
             email.utils.getaddresses(self._message.get_all("CC", [])) + \
             email.utils.getaddresses(self._message.get_all("BCC", []))
         self._recipients = [x[1] for x in addrs]
-        if hasattr(self._message, "bcc"):
-            delattr(self._message, "bcc")
+        self._message.__delitem__("bcc")  # pylint: disable=unnecessary-dunder-call
         self._sender = self._message["from"]
 
     def _make_message_multipart(self):


### PR DESCRIPTION
Remove Python 3.6 and 3.7, which are at [end of life](https://devguide.python.org/versions/) and causing CI failures.  Add Python 3.10 and Python 3.11 in CI tests.  Fix a lint error on most recent pylint.