### PR TITLE
Update a yield statement loop to a yield from statement

### DIFF
--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -315,8 +315,7 @@ def read_csv_database(database_path):
         csvdialect.strict = True
         reader = csv.DictReader(database_file, dialect=csvdialect)
         try:
-            for row in reader:
-                yield row
+            yield from reader
         except csv.Error as err:
             raise exceptions.MailmergeError(
                 f"{database_path}:{reader.line_num}: {err}"


### PR DESCRIPTION
Pylint added a new `use-yield-from` in [version 3.1]. This results in a single linting error when running `tox`. This change updates a `yield` within a loop to a `yield from` per the linter's recommendation.

[version 3.1]: https://pylint.readthedocs.io/en/stable/whatsnew/3/3.1/