### PR TITLE
Update tox envlist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       # Define OS and Python versions to use. 3.x is the latest minor version.
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.x"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.x"]
         os: [ubuntu-latest]
 
     # Sequence of tasks for this job

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 # Local host configuration with one Python 3 version
 [tox]
-envlist = py36, py37, py38, py39, py310
+envlist = py38, py39, py310, py311, py312
 
 # GitHub Actions configuration with multiple Python versions
 # https://github.com/ymyzk/tox-gh-actions#tox-gh-actions-configuration
 [gh-actions]
 python =
-  3.6: py36
-  3.7: py37
   3.8: py38
   3.9: py39
   3.10: py310
+  3.11: py311
+  3.12: py312
 
 # Run unit tests
 # HACK: Pydocstyle fails to find tests.  Invoke a shell to use a glob.


### PR DESCRIPTION
This commit includes two changes:

1. Removes py36 and py37 from the `tox` `envlist` to match the CI changes made in #148
2. Adds Python 3.12 to both `tox.ini` and the GitHub Actions configuration to ensure that the current major version of Python is included in the test suite