### PR TITLE
Improve handling of "Date" header field

### DIFF
--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -58,7 +58,13 @@ class TemplateMessage:
         self._transform_markdown()
         self._transform_attachments()
         self._transform_attachment_references()
-        self._message.add_header('Date', email.utils.formatdate())
+        # Do not add "Date" header if already present
+        # If "Date" header is already present but empty - then delete it
+        hdr_date = self._message.get('Date')
+        if hdr_date is None:
+            self._message.add_header('Date', email.utils.formatdate())
+        elif len(hdr_date) == 0:
+            self._message.__delitem__('Date')
         assert self._sender
         assert self._recipients
         assert self._message

--- a/tests/test_main_output.py
+++ b/tests/test_main_output.py
@@ -638,3 +638,118 @@ def test_complicated(tmpdir):
         >>> message 2 sent
         >>> This was a dry run.  To send messages, use the --no-dry-run option.
     """)
+
+
+def test_date_already_present(tmpdir):
+    """Verify date already_present."""
+
+    # Simple template
+    template_path = Path(tmpdir/"mailmerge_template.txt")
+    template_path.write_text(textwrap.dedent("""\
+        TO: {{email}}
+        FROM: from@test.com
+        Date: Already Present
+
+        Laȝamon 😀 klâwen
+    """), encoding="utf8")
+
+    # Simple database
+    database_path = Path(tmpdir/"mailmerge_database.csv")
+    database_path.write_text(textwrap.dedent("""\
+        email
+        to@test.com
+    """), encoding="utf8")
+
+    # Simple unsecure server config
+    config_path = Path(tmpdir/"mailmerge_server.conf")
+    config_path.write_text(textwrap.dedent("""\
+        [smtp_server]
+        host = open-smtp.example.com
+        port = 25
+    """), encoding="utf8")
+
+    # Run mailmerge
+    runner = click.testing.CliRunner(mix_stderr=False)
+    with tmpdir.as_cwd():
+        result = runner.invoke(main, ["--output-format", "text"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    # Remove the Date string, which will be different each time
+    stdout = copy.deepcopy(result.stdout)
+    #stdout = re.sub(r"Date:.+", "Date: REDACTED", stdout, re.MULTILINE)
+
+    # Verify output
+    assert result.stderr == ""
+    assert stdout == textwrap.dedent("""\
+        >>> message 1
+        TO: to@test.com
+        FROM: from@test.com
+        Date: Already Present
+        MIME-Version: 1.0
+        Content-Type: text/plain; charset="utf-8"
+        Content-Transfer-Encoding: base64
+
+        Laȝamon 😀 klâwen
+
+        >>> message 1 sent
+        >>> Limit was 1 message.  To remove the limit, use the --no-limit option.
+        >>> This was a dry run.  To send messages, use the --no-dry-run option.
+    """)  # noqa: E501
+
+
+def test_date_already_present_but_empty(tmpdir):
+    """Verify date already_present."""
+
+    # Simple template
+    template_path = Path(tmpdir/"mailmerge_template.txt")
+    template_path.write_text(textwrap.dedent("""\
+        TO: {{email}}
+        FROM: from@test.com
+        Date:
+
+        Laȝamon 😀 klâwen
+    """), encoding="utf8")
+
+    # Simple database
+    database_path = Path(tmpdir/"mailmerge_database.csv")
+    database_path.write_text(textwrap.dedent("""\
+        email
+        to@test.com
+    """), encoding="utf8")
+
+    # Simple unsecure server config
+    config_path = Path(tmpdir/"mailmerge_server.conf")
+    config_path.write_text(textwrap.dedent("""\
+        [smtp_server]
+        host = open-smtp.example.com
+        port = 25
+    """), encoding="utf8")
+
+    # Run mailmerge
+    runner = click.testing.CliRunner(mix_stderr=False)
+    with tmpdir.as_cwd():
+        result = runner.invoke(main, ["--output-format", "text"])
+    assert not result.exception
+    assert result.exit_code == 0
+
+    # Remove the Date string, which will be different each time
+    stdout = copy.deepcopy(result.stdout)
+    #stdout = re.sub(r"Date:.+", "Date: REDACTED", stdout, re.MULTILINE)
+
+    # Verify output
+    assert result.stderr == ""
+    assert stdout == textwrap.dedent("""\
+        >>> message 1
+        TO: to@test.com
+        FROM: from@test.com
+        MIME-Version: 1.0
+        Content-Type: text/plain; charset="utf-8"
+        Content-Transfer-Encoding: base64
+
+        Laȝamon 😀 klâwen
+
+        >>> message 1 sent
+        >>> Limit was 1 message.  To remove the limit, use the --no-limit option.
+        >>> This was a dry run.  To send messages, use the --no-dry-run option.
+    """)  # noqa: E501


### PR DESCRIPTION
Improve handling of "Date" header field

Under normal circumstances the "Date" header is added by mailmerge - just as it always has been. 
If "Date" header is already present (from the template) - a new "Date" header is not added. 
If "Date" header is already present but empty - then delete it

Tests for new functionality included.

Summary:
If the "Date" is to be left out - then just add an empty "Date" header into the template

This presents a (backwards compatible) way to let the mail-system add its own "Date" upon queuing into mail-queue.

This PR is related to issue #162 