### PR TITLE
Modernize infra

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: CI
 # Define conditions for when to run this action
 on:
   pull_request: # Run on all pull requests
-  push: # Run on all pushes to master
+  push: # Run on all pushes to the integration and release branches
     branches:
       - main
       - develop
@@ -29,14 +29,15 @@ jobs:
       # Check out latest code
       # Docs: https://github.com/actions/checkout
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       # Set up Python
       # Docs: https://github.com/actions/setup-python
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
 
       # Install dependencies
       # https://github.com/ymyzk/tox-gh-actions#workflow-configuration
@@ -55,7 +56,7 @@ jobs:
       # Upload coverage report
       # https://github.com/codecov/codecov-action
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: awdeorio/mailmerge

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: pyproject.toml
 
       # Install dependencies
       # https://github.com/ymyzk/tox-gh-actions#workflow-configuration

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Mailmerge
 =========
 
-[![CI main](https://github.com/awdeorio/mailmerge/workflows/CI/badge.svg?branch=develop)](https://github.com/awdeorio/mailmerge/actions?query=branch%3Adevelop)
+[![CI](https://github.com/awdeorio/mailmerge/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/awdeorio/mailmerge/actions/workflows/main.yml?query=branch%3Adevelop)
 [![codecov](https://codecov.io/gh/awdeorio/mailmerge/branch/develop/graph/badge.svg)](https://codecov.io/gh/awdeorio/mailmerge)
 [![PyPI](https://img.shields.io/pypi/v/mailmerge.svg)](https://pypi.org/project/mailmerge/)
 


### PR DESCRIPTION
- Rename `CLAUDE.md` to `AGENTS.md` and leave a one-line `CLAUDE.md` pointer, so the project instructions live under the tool-agnostic filename.
- Upgrade GitHub Actions to their latest majors:
  - `actions/checkout` v2 -> v6
  - `actions/setup-python` v2 -> v6
  - `codecov/codecov-action` v4 -> v7
- Add pip dependency caching to the test job (keyed on `pyproject.toml`) to speed up the Python version matrix.
- Fix a stale CI comment that referred to pushes to `master` (branches are `main` and `develop`).
