### PR TITLE
Make Markdown extensions configurable

### DIFF
--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -8,6 +8,7 @@ import time
 import textwrap
 from pathlib import Path
 import csv
+import configparser
 import click
 from .template_message import TemplateMessage
 from .sendmail_client import SendmailClient
@@ -45,6 +46,11 @@ from . import exceptions
     help="template email (mailmerge_template.txt)"
 )
 @click.option(
+    "--markdown-extension", "markdown_extensions",
+    multiple=True,
+    help="Markdown extension to enable (repeat the option, e.g. --markdown-extension fenced_code).",
+)
+@click.option(
     "--database", "database_path",
     default="mailmerge_database.csv",
     type=click.Path(),
@@ -63,7 +69,7 @@ from . import exceptions
     help="Output format (colorized).",
 )
 def main(*, sample, dry_run, limit, no_limit, resume,
-         template_path, database_path, config_path,
+         template_path, markdown_extensions, database_path, config_path,
          output_format):
     """
     Mailmerge is a simple, command line mail merge tool.
@@ -82,6 +88,14 @@ def main(*, sample, dry_run, limit, no_limit, resume,
     database_path = Path(database_path)
     config_path = Path(config_path)
 
+    if not markdown_extensions:
+        parser = configparser.ConfigParser()
+        parser.read(config_path)
+        configured = parser.get("markdown", "extensions", fallback="nl2br")
+        markdown_extensions = tuple(
+            extension.strip() for extension in configured.split(",") if extension.strip()
+        )
+
     # Make sure input files exist and provide helpful prompts
     check_input_files(template_path, database_path, config_path, sample)
 
@@ -93,7 +107,10 @@ def main(*, sample, dry_run, limit, no_limit, resume,
     # Run
     message_num = 1 + start
     try:
-        template_message = TemplateMessage(template_path)
+        template_message = TemplateMessage(
+            template_path,
+            markdown_extensions=markdown_extensions,
+        )
         csv_database = read_csv_database(database_path)
         sendmail_client = SendmailClient(config_path, dry_run)
 

--- a/mailmerge/__main__.py
+++ b/mailmerge/__main__.py
@@ -9,6 +9,7 @@ import textwrap
 from pathlib import Path
 import csv
 import configparser
+import json
 import click
 from .template_message import TemplateMessage
 from .sendmail_client import SendmailClient
@@ -96,6 +97,17 @@ def main(*, sample, dry_run, limit, no_limit, resume,
             extension.strip() for extension in configured.split(",") if extension.strip()
         )
 
+    extension_configs = {}
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    raw_extension_configs = parser.get("markdown", "extension_configs", fallback="{}")
+    try:
+        extension_configs = json.loads(raw_extension_configs)
+    except json.JSONDecodeError as err:
+        raise exceptions.MailmergeError(
+            f"Invalid [markdown] extension_configs JSON: {err}"
+        ) from err
+
     # Make sure input files exist and provide helpful prompts
     check_input_files(template_path, database_path, config_path, sample)
 
@@ -110,6 +122,7 @@ def main(*, sample, dry_run, limit, no_limit, resume,
         template_message = TemplateMessage(
             template_path,
             markdown_extensions=markdown_extensions,
+            extension_configs=extension_configs,
         )
         csv_database = read_csv_database(database_path)
         sendmail_client = SendmailClient(config_path, dry_run)

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -28,9 +28,10 @@ class TemplateMessage:
     # more than one public method.
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, template_path):
+    def __init__(self, template_path, markdown_extensions=None):
         """Initialize variables and Jinja2 template."""
         self.template_path = Path(template_path)
+        self.markdown_extensions = list(markdown_extensions or ["nl2br"])
         self._message = None
         self._sender = None
         self._recipients = None
@@ -172,7 +173,7 @@ class TemplateMessage:
         # https://docs.python.org/3/library/email.mime.html#email.mime.text.MIMEText
         html = markdown.markdown(
             text,
-            extensions=['nl2br', 'fenced_code', 'tables'],
+            extensions=self.markdown_extensions,
         )
         html_payload = email.mime.text.MIMEText(
             f"<html><body>{html}</body></html>",

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -28,10 +28,12 @@ class TemplateMessage:
     # more than one public method.
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, template_path, markdown_extensions=None):
+    def __init__(self, template_path, markdown_extensions=None,
+                 extension_configs=None):
         """Initialize variables and Jinja2 template."""
         self.template_path = Path(template_path)
         self.markdown_extensions = list(markdown_extensions or ["nl2br"])
+        self.extension_configs = extension_configs or {}
         self._message = None
         self._sender = None
         self._recipients = None
@@ -174,6 +176,7 @@ class TemplateMessage:
         html = markdown.markdown(
             text,
             extensions=self.markdown_extensions,
+            extension_configs=self.extension_configs,
         )
         html_payload = email.mime.text.MIMEText(
             f"<html><body>{html}</body></html>",

--- a/mailmerge/template_message.py
+++ b/mailmerge/template_message.py
@@ -170,7 +170,10 @@ class TemplateMessage:
         # multipart/alternative message as per RFC 2046.
         #
         # https://docs.python.org/3/library/email.mime.html#email.mime.text.MIMEText
-        html = markdown.markdown(text, extensions=['nl2br'])
+        html = markdown.markdown(
+            text,
+            extensions=['nl2br', 'fenced_code', 'tables'],
+        )
         html_payload = email.mime.text.MIMEText(
             f"<html><body>{html}</body></html>",
             _subtype="html",

--- a/tests/test_markdown_extensions.py
+++ b/tests/test_markdown_extensions.py
@@ -1,0 +1,61 @@
+"""Tests for configurable Markdown extensions."""
+
+import pytest
+
+from mailmerge import TemplateMessage
+
+
+def _template(tmp_path):
+    path = tmp_path / "template.txt"
+    path.write_text(
+        "TO: to@example.com\n"
+        "SUBJECT: Markdown\n"
+        "FROM: from@example.com\n"
+        "CONTENT-TYPE: text/markdown\n\n"
+        "```terraform\n"
+        "resource \"example\" \"demo\" {\n"
+        "  name = \"demo\"\n"
+        "}\n"
+        "```\n",
+        encoding="utf8",
+    )
+    return path
+
+
+def _html(message):
+    return next(
+        part for part in message.walk()
+        if part.get_content_type() == "text/html"
+    ).get_payload(decode=True).decode("utf8")
+
+
+def test_fenced_code_is_configurable(tmp_path):
+    """Fenced code is rendered only when the extension is enabled."""
+    template = _template(tmp_path)
+
+    _, _, default_message = TemplateMessage(template).render({})
+    default_html = _html(default_message)
+    assert "<pre>" not in default_html
+
+    _, _, configured_message = TemplateMessage(
+        template,
+        markdown_extensions=["nl2br", "fenced_code"],
+    ).render({})
+    configured_html = _html(configured_message)
+    assert "<pre><code class=\"language-terraform\">" in configured_html
+
+
+def test_extension_configs_are_forwarded(tmp_path):
+    """Extension configuration is passed to Python-Markdown."""
+    pytest.importorskip("pygments")
+    template = _template(tmp_path)
+    _, _, message = TemplateMessage(
+        template,
+        markdown_extensions=["fenced_code", "codehilite"],
+        extension_configs={
+            "codehilite": {"noclasses": True, "guess_lang": False},
+        },
+    ).render({})
+    html = _html(message)
+    assert "class=\"codehilite\"" in html
+    assert "style=\"" in html

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -319,7 +319,10 @@ def test_markdown(tmp_path):
                                                   'text/html')
 
     # Verify rendered Markdown
-    rendered = markdown.markdown(plaintext, extensions=['nl2br'])
+    rendered = markdown.markdown(
+        plaintext,
+        extensions=['nl2br', 'fenced_code', 'tables'],
+    )
     expected = html5lib.parse(rendered)
 
     htmltext_document = html5lib.parse(htmltext)

--- a/tests/test_template_message.py
+++ b/tests/test_template_message.py
@@ -319,10 +319,7 @@ def test_markdown(tmp_path):
                                                   'text/html')
 
     # Verify rendered Markdown
-    rendered = markdown.markdown(
-        plaintext,
-        extensions=['nl2br', 'fenced_code', 'tables'],
-    )
+    rendered = markdown.markdown(plaintext, extensions=['nl2br'])
     expected = html5lib.parse(rendered)
 
     htmltext_document = html5lib.parse(htmltext)


### PR DESCRIPTION
## Summary

Make the Python-Markdown extensions used for `Content-Type: text/markdown` messages configurable.

## Motivation

Mailmerge currently renders Markdown with a hard-coded extension list:

```python
markdown.markdown(text, extensions=["nl2br"])
```

This prevents templates from using common Markdown features such as fenced code blocks and tables.

For example:

````markdown
```terraform
resource "google_compute_instance" "example" {
  name = "demo"
}
```
````

Without the `fenced_code` extension, this is not rendered as a proper `<pre><code>` block.

## Changes

- Configure Markdown extensions from the mailmerge configuration:

  ```ini
  [markdown]
  extensions = nl2br,fenced_code,tables,codehilite
  extension_configs = {"codehilite": {"noclasses": true, "guess_lang": false}}
  ```

- Add a repeatable `--markdown-extension` CLI option.
- Support extension-specific `extension_configs`.
- Preserve the current default behavior when no configuration is provided.
- Add tests for configurable extensions and fenced code blocks.

With `noclasses = true`, `codehilite` emits inline styles, avoiding a separate CSS file or `<style>` block in email messages.

Closes #175
